### PR TITLE
Fix error when child is rendered as null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ class SwitchCSSTransitionGroup extends Component {
     let switchKey = undefined
     React.Children.forEach(this.props.children,
       (child) => {
-        if(matchPath(this.props.location.pathname,child.props) && switchKey === undefined){
+        if(child !== null && matchPath(this.props.location.pathname,child.props) && switchKey === undefined){
           switchKey = child.props.path
         }
       }


### PR DESCRIPTION
Error occurred when a the component's child has conditional rendering (ie `{this.state.show && <div />}`). The fix is a basic null check.